### PR TITLE
Adding in generate command to turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ To build all apps and packages, run the following command:
 pnpm run build
 ```
 
+### Generate: SSG
+
+To statically generate this project:
+
+```
+pnpm run generate
+```
+
 ### Remote Caching
 
 Turborepo can use a technique known as [Remote Caching](https://turborepo.org/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "build": "turbo run build",
+    "generate": "turbo run generate",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,13 @@
         "**/.vitepress/dist/**"
       ]
     },
+    "generate" : {
+      "dependsOn": ["^generate"],
+      "outputs": [
+        "dist/**",
+        ".output/**"
+      ]
+    },
     "lint": {
       "outputs": []
     },


### PR DESCRIPTION
I was having some trouble deploying this project to Netlify using `pnpm run build` (issue #345). I figured that I needed to statically generate the project (SSG) instead. This adds in the command and documentation to run `pnpm run generate`.